### PR TITLE
Merge auto update into development

### DIFF
--- a/src/pixhdl/auto_update.c
+++ b/src/pixhdl/auto_update.c
@@ -26,11 +26,11 @@ int update (const char * current_version)
         log_info("pixhdl is up to date (v%s).", current_version);
     } else if (strcmp(latest_version, current_version) < 0) {
         // Local version is ahead of latest stable release
-        log_info("Your version of aliases (v%s) is ahead of the latest stable release (v%s).", current_version, latest_version);
+        log_info("Your version of pixhdl (v%s) is ahead of the latest stable release (v%s).", current_version, latest_version);
     } else {
         // Newer stable version found and should be installed
-        log_info("Newer stable version of aliases found: v%s", latest_version);
-        log_info("Downloading and installing version v%s of aliases...", latest_version);
+        log_info("Newer stable version of pixhdl found: v%s", latest_version);
+        log_info("Downloading and installing version v%s of pixhdl...", latest_version);
 
         // Launch the update command
         ret = system(UPDATE_COMMAND);

--- a/src/pixhdl/auto_update.c
+++ b/src/pixhdl/auto_update.c
@@ -1,0 +1,51 @@
+#include "auto_update.h"
+
+
+int update (const char * current_version)
+{
+    // File pointer to read output of popen() (to get latest version)
+    FILE *fp;
+    // Character array to store the latest version number
+    char latest_version[VERSION_WIDTH];
+    // Return value of the system() call
+    int ret = 0;
+
+    log_info("Checking for updates...");
+
+    // Try to get the latest version via curl
+    fp = popen(LATEST_VERSION, "r");
+    // Check if popen() call was successful
+    check(fp, "Couldn't get latest version. Check your internet connection.");
+    // Get the latest version number
+    fgets(latest_version, VERSION_WIDTH, fp);
+    // Check that the version number is valid
+    check(strlen(latest_version), "Couldn't get latest version. Check your internet connection.");
+
+    if (strcmp(latest_version, current_version) == 0) {
+        // Aliases is up to date
+        log_info("pixhdl is up to date (v%s).", current_version);
+    } else if (strcmp(latest_version, current_version) < 0) {
+        // Local version is ahead of latest stable release
+        log_info("Your version of aliases (v%s) is ahead of the latest stable release (v%s).", current_version, latest_version);
+    } else {
+        // Newer stable version found and should be installed
+        log_info("Newer stable version of aliases found: v%s", latest_version);
+        log_info("Downloading and installing version v%s of aliases...", latest_version);
+
+        // Launch the update command
+        ret = system(UPDATE_COMMAND);
+        // Check that the update command was successful
+        check(ret == 0, "Error downloading version v%s.", latest_version);
+
+        log_info("Done! Version v%s of pixhdl is now installed.", latest_version);
+    }
+
+    // Check that pclose() is successful
+    check(pclose(fp) != -1, "Couldn't complete update.");
+
+    return 0;
+
+error:
+    if (fp) pclose(fp);
+    return 1;
+}

--- a/src/pixhdl/auto_update.h
+++ b/src/pixhdl/auto_update.h
@@ -1,0 +1,18 @@
+#ifndef __AUTO_UPDATE_H__
+#define __AUTO_UPDATE_H__
+
+#include "dbg.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define VERSION_WIDTH 6
+#define LATEST_VERSION "curl -s https://github.com/kokkonisd/pixhdl/releases/latest | grep -Eo \"/tag/(.+)>\" | head -c 9 | tail -c 3"
+
+#define UPDATE_COMMAND "TMPDWN=$(curl -s https://api.github.com/repos/kokkonisd/pixhdl/releases/latest | grep \"tag_name\" | awk '{print \"https://github.com/kokkonisd/pixhdl/releases/download/\" substr($2, 2, length($2)-3) \"/pixhdl-\" substr($2, 3, length($2)-4) \".tar.gz\"}') && curl -L -s $TMPDWN -o /tmp/pixhdl_latest.tar.gz && tar xvzf /tmp/pixhdl_latest.tar.gz -C /tmp/ && cd /tmp/pixhdl-* && make clean && make uninstall && make install && cd .. && rm -rf pixhdl-* pixhdl_latest*"
+
+
+int update ();
+
+
+#endif

--- a/src/pixhdl/auto_update.h
+++ b/src/pixhdl/auto_update.h
@@ -9,7 +9,7 @@
 #define VERSION_WIDTH 6
 #define LATEST_VERSION "curl -s https://github.com/kokkonisd/pixhdl/releases/latest | grep -Eo \"/tag/(.+)>\" | head -c 11 | tail -c 5"
 
-#define UPDATE_COMMAND "TMPDWN=$(curl -s https://api.github.com/repos/kokkonisd/pixhdl/releases/latest | grep \"tag_name\" | awk '{print \"https://github.com/kokkonisd/pixhdl/archive/\" substr($2, 2, length($2)-3) \"/pixhdl-\" substr($2, 3, length($2)-4) \".tar.gz\"}') && curl -L -s $TMPDWN -o /tmp/pixhdl_latest.tar.gz && tar xvzf /tmp/pixhdl_latest.tar.gz -C /tmp/ && cd /tmp/pixhdl-* && make clean && make uninstall && make && make install && cd .. && rm -rf pixhdl-* pixhdl_latest*"
+#define UPDATE_COMMAND "TMPDWN=$(curl -s https://api.github.com/repos/kokkonisd/pixhdl/releases/latest | grep \"tag_name\" | awk '{print \"https://github.com/kokkonisd/pixhdl/archive/\" substr($2, 2, length($2)-3) \"/pixhdl-\" substr($2, 3, length($2)-4) \".tar.gz\"}') && curl -L -s $TMPDWN -o /tmp/pixhdl_latest.tar.gz && tar xvzf /tmp/pixhdl_latest.tar.gz -C /tmp/ && cd /tmp/pixhdl-* && make clean && sudo make uninstall && make && sudo make install && cd .. && rm -rf pixhdl-* pixhdl_latest*"
 
 
 int update ();

--- a/src/pixhdl/auto_update.h
+++ b/src/pixhdl/auto_update.h
@@ -7,7 +7,7 @@
 
 
 #define VERSION_WIDTH 6
-#define LATEST_VERSION "curl -s https://github.com/kokkonisd/pixhdl/releases/latest | grep -Eo \"/tag/(.+)>\" | head -c 9 | tail -c 3"
+#define LATEST_VERSION "curl -s https://github.com/kokkonisd/pixhdl/releases/latest | grep -Eo \"/tag/(.+)>\" | head -c 11 | tail -c 5"
 
 #define UPDATE_COMMAND "TMPDWN=$(curl -s https://api.github.com/repos/kokkonisd/pixhdl/releases/latest | grep \"tag_name\" | awk '{print \"https://github.com/kokkonisd/pixhdl/releases/download/\" substr($2, 2, length($2)-3) \"/pixhdl-\" substr($2, 3, length($2)-4) \".tar.gz\"}') && curl -L -s $TMPDWN -o /tmp/pixhdl_latest.tar.gz && tar xvzf /tmp/pixhdl_latest.tar.gz -C /tmp/ && cd /tmp/pixhdl-* && make clean && make uninstall && make install && cd .. && rm -rf pixhdl-* pixhdl_latest*"
 

--- a/src/pixhdl/auto_update.h
+++ b/src/pixhdl/auto_update.h
@@ -9,7 +9,7 @@
 #define VERSION_WIDTH 6
 #define LATEST_VERSION "curl -s https://github.com/kokkonisd/pixhdl/releases/latest | grep -Eo \"/tag/(.+)>\" | head -c 11 | tail -c 5"
 
-#define UPDATE_COMMAND "TMPDWN=$(curl -s https://api.github.com/repos/kokkonisd/pixhdl/releases/latest | grep \"tag_name\" | awk '{print \"https://github.com/kokkonisd/pixhdl/releases/download/\" substr($2, 2, length($2)-3) \"/pixhdl-\" substr($2, 3, length($2)-4) \".tar.gz\"}') && curl -L -s $TMPDWN -o /tmp/pixhdl_latest.tar.gz && tar xvzf /tmp/pixhdl_latest.tar.gz -C /tmp/ && cd /tmp/pixhdl-* && make clean && make uninstall && make install && cd .. && rm -rf pixhdl-* pixhdl_latest*"
+#define UPDATE_COMMAND "TMPDWN=$(curl -s https://api.github.com/repos/kokkonisd/pixhdl/releases/latest | grep \"tag_name\" | awk '{print \"https://github.com/kokkonisd/pixhdl/archive/\" substr($2, 2, length($2)-3) \"/pixhdl-\" substr($2, 3, length($2)-4) \".tar.gz\"}') && curl -L -s $TMPDWN -o /tmp/pixhdl_latest.tar.gz && tar xvzf /tmp/pixhdl_latest.tar.gz -C /tmp/ && cd /tmp/pixhdl-* && make clean && make uninstall && make && make install && cd .. && rm -rf pixhdl-* pixhdl_latest*"
 
 
 int update ();

--- a/src/pixhdl/pixhdl.c
+++ b/src/pixhdl/pixhdl.c
@@ -31,7 +31,7 @@ int main (int argc, char * argv[])
     if (argc == 1) return print_help_screen();
 
     // Parse optional arguments
-    while ((ra = getopt(argc, argv, ":vho:")) != -1) {
+    while ((ra = getopt(argc, argv, ":vho:u")) != -1) {
         switch (ra) {
             case 'v':
                 // Print version number
@@ -46,6 +46,9 @@ int main (int argc, char * argv[])
             case 'o':
                 out_filename = optarg;
                 break;
+
+            case 'u':
+                return update(VERSION);
 
             case '?':
             default:

--- a/src/pixhdl/pixhdl.h
+++ b/src/pixhdl/pixhdl.h
@@ -16,6 +16,7 @@ Usage: pixhdl [options] <VHDL file>\n\
 #include "print_entity.h"
 #include "parser.h"
 #include "generate_svg.h"
+#include "auto_update.h"
 
 
 /**


### PR DESCRIPTION
Pixhdl can now update automatically, by downloading the latest release into /tmp/ and installing.