### PR TITLE
Fix auto_update.h update signature

### DIFF
--- a/src/pixhdl/auto_update.h
+++ b/src/pixhdl/auto_update.h
@@ -63,7 +63,7 @@
  *
  * @return (`int`): 1 if successful, 0 otherwise.
  */
-int update ();
+int update (const char * current_version);
 
 
 #endif


### PR DESCRIPTION
I was going to try out the tool, but got a compliation error.
Luckly, it's a trivial one. The `update` signature did not match the `update` function implementation, causing the build to fail.